### PR TITLE
Set const sampling frequency

### DIFF
--- a/FilterDerivative.cpp
+++ b/FilterDerivative.cpp
@@ -1,13 +1,19 @@
 #include "FilterDerivative.h"
 #include "Arduino.h"
 
+float FilterDerivative::FilterDerivative( float fsam ) {
+  fs = fsam;
+}
 float FilterDerivative::input( float inVal ) {
+  if (fs < 0.0) {
   long thisUS = micros();
   float dt = 1e-6*float(thisUS - LastUS);   // cast to float here, for math
   LastUS = thisUS;                          // update this now
-  
+
   Derivative = (inVal-LastInput) / dt;
-    
+  }
+  else{Derivative = (inVal-LastInput) * fs;}
+
   LastInput = inVal;
   return output();
 }

--- a/FilterDerivative.h
+++ b/FilterDerivative.h
@@ -5,9 +5,10 @@
 struct FilterDerivative {
   long LastUS;
   float LastInput;
+  float fs =-1;
   
   float Derivative;
-  
+  FilterDerivative(float fsam =-1);
   float input( float inVal );
   
   float output();

--- a/FilterOnePole.cpp
+++ b/FilterOnePole.cpp
@@ -1,25 +1,28 @@
 #include "FilterOnePole.h"
 #include "FloatDefine.h"
 
-FilterOnePole::FilterOnePole( FILTER_TYPE ft, float fc, float initialValue ) {
-  setFilter( ft, fc, initialValue );
+FilterOnePole::FilterOnePole( FILTER_TYPE ft, float fc, float initialValue, float fs ) {
+  setFilter( ft, fc, initialValue, fs );
 }
 
-void FilterOnePole::setFilter( FILTER_TYPE ft, float fc, float initialValue ) {
+void FilterOnePole::setFilter( FILTER_TYPE ft, float fc, float initialValue, float fsam ) {
   FT = ft;
   setFrequency( fc );
 
   Y = initialValue;
   Ylast = initialValue;
   X = initialValue;
-
+  fs = fsam;
   LastUS = micros();
 }
 
 float FilterOnePole::input( float inVal ) {
-  long time = micros();
-  ElapsedUS = float(time - LastUS);   // cast to float here, for math
-  LastUS = time;                      // update this now
+  if (fs < 0.0){
+    long time = micros();
+    ElapsedUS = float(time - LastUS);   // cast to float here, for math
+    LastUS = time;                      // update this now
+  }
+  else{ElapsedUS = 1e6/fs;}
 
   // shift the data values
   Ylast = Y;

--- a/FilterOnePole.h
+++ b/FilterOnePole.h
@@ -30,11 +30,12 @@ struct FilterOnePole {
   // because the delta will still be correct (always positive and small)
   float ElapsedUS;   // time since last update
   long LastUS;       // last time measured
+  float fs = -1.0;
 
-  FilterOnePole( FILTER_TYPE ft=LOWPASS, float fc=1.0, float initialValue=0 );
-  
+  FilterOnePole( FILTER_TYPE ft=LOWPASS, float fc=1.0, float initialValue=0, float fs=-1.0 );
+
   // sets or resets the parameters and state of the filter
-  void setFilter( FILTER_TYPE ft, float tauS, float initialValue );
+  void setFilter( FILTER_TYPE ft, float tauS, float initialValue, float fsam =-1.0 );
 
   void setFrequency( float newFrequency );
   

--- a/FilterTwoPole.h
+++ b/FilterTwoPole.h
@@ -43,13 +43,15 @@ struct FilterTwoPole {
 
   long LastTimeUS;  // last time measured
 
-  FilterTwoPole( float frequency0 = 1, float qualityFactor = 1, float xInit = 0);
+  float fs = -1.0; // sampling Frequency
+
+  FilterTwoPole( float frequency0 = 1, float qualityFactor = 1, float xInit = 0, float fsam = -1);
 
   void setQ( float qualityFactor );
 
   void setFrequency0( float f );
 
-  void setAsFilter( OSCILLATOR_TYPE ft, float frequency3db, float initialValue=0 );
+  void setAsFilter( OSCILLATOR_TYPE ft, float frequency3db, float initialValue=0, float fsam = -1 );
 
   float input( float drive = 0 );
 


### PR DESCRIPTION
### New Features
 - Added _float fs_ to OnePole, TwoPole, and Derivative structs, set to -1 by default
- Sampling rate can optionally be set in the constructors
- OnePole is working an tested, TwoPole and Derivative remain untested